### PR TITLE
Move from method to functions

### DIFF
--- a/R/transform.R
+++ b/R/transform.R
@@ -66,7 +66,7 @@
 #' on the number of entries the transformation will be performed either on one or 
 #' both markers.
 #' 
-#'  @param ...
+#'@param ...
 #' Additional parameters passed to `convertMtime`, as for example `L`, `U`, 
 #' and `tR`.
 #'  

--- a/R/transform.R
+++ b/R/transform.R
@@ -144,11 +144,11 @@ mobilityTransform <- function(x, marker,
 #' transformNumeric(x = rtime, marker = marker)
 #' transformNumeric(x = rtime, marker = marker[-1,], U = 30, L = 90)
 #' 
-.transformNumeric <- function(x, marker, ...) {
+.transformNumeric <- function(x, marker, tR = tR, U = U, L = L) {
 
   convertMtime(x/60, 
                rtime = marker$rtime/60, 
-               mobility = marker$mobility, ...)
+               mobility = marker$mobility, tR = tR, U = U, L = L)
   
 }
 
@@ -171,12 +171,12 @@ mobilityTransform <- function(x, marker,
 #'                      mobility = c(0, 2000))
 #' .transformSpectra(x = spectra_data, marker = marker)
 
-.transformSpectra <- function(x, marker, ...) {
+.transformSpectra <- function(x, marker, tR = tR, U = U, L = L) {
   
   xTransf <- x
   xTransf$rtime <- convertMtime(xTransf$rtime/60, 
                             rtime = marker$rtime/60, 
-                            mobility = marker$mobility, ...)
+                            mobility = marker$mobility, tR = tR, U = U, L = L)
   
   ## Data needs to be ordered by the migration time and spectrum IDs needs to 
   ## be removed to prevent errors in xcms 
@@ -210,7 +210,7 @@ mobilityTransform <- function(x, marker,
 #'                      
 #' .transformOnDiskMSnExp(x = raw_data, marker = marker)
 
-.transformOnDiskMSnExp <- function(x, marker, ...) {
+.transformOnDiskMSnExp <- function(x, marker, tR = tR, U = U, L = L) {
   ## sanity checks
   if (!all(c("fileIdx") %in% colnames(marker))) {
     stop("Missing column 'fileIdx'")}
@@ -224,7 +224,7 @@ mobilityTransform <- function(x, marker,
     fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime <- 
       convertMtime(x = rt_file[[i]]/60, 
                    rtime = marker[marker$fileIdx == i,]$rtime/60, 
-                   mobility = marker[marker$fileIdx == i,]$mobility, ...)
+                   mobility = marker[marker$fileIdx == i,]$mobility, tR = tR, U = U, L = L)
     
     ## Data needs to be ordered by the migration time and spectrum IDs needs to 
     ## be removed to prevent errors in xcms 

--- a/R/transform.R
+++ b/R/transform.R
@@ -224,12 +224,14 @@ mobilityTransform <- function(x, marker,
     fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime <- 
       convertMtime(x = rt_file[[i]]/60, 
                    rtime = marker[marker$fileIdx == i,]$rtime/60, 
-                   mobility = marker[marker$fileIdx == i,]$mobility, tR = tR, U = U, L = L)
+                   mobility = marker[marker$fileIdx == i,]$mobility, 
+                   tR = tR, U = U, L = L)
     
     ## Data needs to be ordered by the migration time and spectrum IDs needs to 
     ## be removed to prevent errors in xcms 
     fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime <- 
-      order(fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime)
+      order(fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime, 
+            decreasing = T)
     
   }
   

--- a/R/transform.R
+++ b/R/transform.R
@@ -91,7 +91,7 @@
 #'
 #'@export
 
-mobilityTransform <- function(x, marker, ...) {
+mobilityTransform <- function(x, marker, tR, U, L) {
   
   ## sanity checks
   if (!class(x) %in% c("numeric","Spectra","OnDiskMSnExp")) 
@@ -106,18 +106,18 @@ mobilityTransform <- function(x, marker, ...) {
   if (is(x, "numeric")) {
     FUN = .transformNumeric
     FUN <- match.fun(FUN)
-    do.call(FUN, list(x = x, marker = marker, ...))
+    do.call(FUN, list(x = x, marker = marker, tR, U, L))
   }
   else if (is(x, "Spectra")) {
     FUN = .transformSpectra
     FUN <- match.fun(FUN)
-    do.call(FUN, list(x = x, marker = marker, ...))
+    do.call(FUN, list(x = x, marker = marker, tR, U, L))
   }
   
   else if (is(x, "OnDiskMSnExp")) {
     FUN = .transformOnDiskMSnExp
     FUN <- match.fun(FUN)
-    do.call(FUN, list(x = x, marker = marker, ...))
+    do.call(FUN, list(x = x, marker = marker, tR, U, L))
   }
   
   
@@ -141,11 +141,11 @@ mobilityTransform <- function(x, marker, ...) {
 #' transformNumeric(x = rtime, marker = marker)
 #' transformNumeric(x = rtime, marker = marker[-1,], U = 30, L = 90)
 #' 
-.transformNumeric <- function(x, marker, ...) {
+.transformNumeric <- function(x, marker, tR, U, L) {
 
   convertMtime(x/60, 
                rtime = marker$rtime/60, 
-               mobility = marker$mobility, ...)
+               mobility = marker$mobility, tR, U, L)
   
 }
 
@@ -168,12 +168,12 @@ mobilityTransform <- function(x, marker, ...) {
 #'                      mobility = c(0, 2000))
 #' .transformSpectra(x = spectra_data, marker = marker)
 
-.transformSpectra <- function(x, marker, ...) {
+.transformSpectra <- function(x, marker, tR, U, L) {
   
   xTransf <- x
   xTransf$rtime <- convertMtime(xTransf$rtime/60, 
                             rtime = marker$rtime/60, 
-                            mobility = marker$mobility, ...)
+                            mobility = marker$mobility, tR, U, L)
   
   ## Data needs to be ordered by the migration time and spectrum IDs needs to 
   ## be removed to prevent errors in xcms 
@@ -207,7 +207,7 @@ mobilityTransform <- function(x, marker, ...) {
 #'                      
 #' .transformOnDiskMSnExp(x = raw_data, marker = marker)
 
-.transformOnDiskMSnExp <- function(x, marker, ...) {
+.transformOnDiskMSnExp <- function(x, marker, tR, U, L) {
   ## sanity checks
   if (!all(c("fileIdx") %in% colnames(marker))) {
     stop("Missing column 'fileIdx'")}
@@ -221,7 +221,7 @@ mobilityTransform <- function(x, marker, ...) {
     fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime <- 
       convertMtime(x = rt_file[[i]]/60, 
                    rtime = marker[marker$fileIdx == i,]$rtime/60, 
-                   mobility = marker[marker$fileIdx == i,]$mobility, ...)
+                   mobility = marker[marker$fileIdx == i,]$mobility, tR, U, L)
     
     ## Data needs to be ordered by the migration time and spectrum IDs needs to 
     ## be removed to prevent errors in xcms 

--- a/R/transform.R
+++ b/R/transform.R
@@ -91,34 +91,37 @@
 #'
 #'@export
 
-setGeneric("mobilityTransform", function(x, marker, ...)
-  standardGeneric("mobilityTransform"))
-
-
-setMethod(
-  "mobilityTransform", 
-  signature(x = "numeric"), 
-  function(x, marker, ...){
-    .transformNumeric(x, marker, ...)
+mobilityTransform <- function(x, marker, ...) {
+  
+  ## sanity checks
+  if (!class(x) %in% c("numeric","Spectra","OnDiskMSnExp")) 
+    stop("'x' needs to be of class 'numeric', 'Spectra' or 'OnDistMSnExp' but 
+          not class '", class(x),"'")
+  if (missing(marker)) {
+    stop("Missing data.frame 'marker' with marker information")}
+  if (!all(c("rtime","mobility") %in% colnames(marker))) {
+    stop("Missing column 'rtime', 'mobility' or both")}
+  
+  
+  if (is(x, "numeric")) {
+    FUN = .transformNumeric
+    FUN <- match.fun(FUN)
+    do.call(FUN, list(x = x, marker = marker, ...))
   }
-)
-
-setMethod(
-  "mobilityTransform", 
-  signature(x = "Spectra"),
-  function(x, marker, ...){
-    .transformSpectra(x, marker, ...)
-  }
-)
-
-setMethod(
-  "mobilityTransform", 
-  signature(x = "OnDiskMSnExp"),
-  function(x, marker, ...){
-    .transformOnDiskMSnExp(x, marker, ...)
+  else if (is(x, "Spectra")) {
+    FUN = .transformSpectra
+    FUN <- match.fun(FUN)
+    do.call(FUN, list(x = x, marker = marker, ...))
   }
   
-)
+  else if (is(x, "OnDiskMSnExp")) {
+    FUN = .transformOnDiskMSnExp
+    FUN <- match.fun(FUN)
+    do.call(FUN, list(x = x, marker = marker, ...))
+  }
+  
+  
+}
 
 #' @name .transformNumeric
 #' 
@@ -139,15 +142,7 @@ setMethod(
 #' transformNumeric(x = rtime, marker = marker[-1,], U = 30, L = 90)
 #' 
 .transformNumeric <- function(x, marker, ...) {
-  ## sanity checks
-  if (!class(x) %in% c("numeric"))
-    stop("'x' needs to be of class 'numeric' but not class '", class(x),"'")
-  if (missing(marker)) {
-    stop("Missing data.frame 'marker' with marker information")}
-  if (!all(c("rtime","mobility") %in% colnames(marker))) {
-    stop("Missing column 'rtime', 'mobility' or both")}
-  
-  
+
   convertMtime(x/60, 
                rtime = marker$rtime/60, 
                mobility = marker$mobility, ...)
@@ -174,14 +169,6 @@ setMethod(
 #' .transformSpectra(x = spectra_data, marker = marker)
 
 .transformSpectra <- function(x, marker, ...) {
-  ## sanity checks
-  if (!class(x) %in% c("Spectra"))
-    stop("'x' needs to be of class 'Spectra' but not class '", class(x),"'")
-  if (missing(marker)) {
-    stop("Missing data.frame 'marker' with marker information")}
-  if (!all(c("rtime","mobility") %in% colnames(marker))) {
-    stop("Missing column 'rtime', 'mobility' or both")}
-  
   
   xTransf <- x
   xTransf$rtime <- convertMtime(xTransf$rtime/60, 
@@ -222,13 +209,8 @@ setMethod(
 
 .transformOnDiskMSnExp <- function(x, marker, ...) {
   ## sanity checks
-  if (!class(x) %in% c("OnDiskMSnExp"))
-    stop("'x' needs to be of class 'OnDistMSnExp' but not class '", 
-         class(x),"'")
-  if (missing(marker)) {
-    stop("Missing data.frame 'marker' with marker information")}
-  if (!all(c("rtime","mobility","fileIdx") %in% colnames(marker))) {
-    stop("Missing column 'rtime', 'mobility', 'fileIdx' or all")}
+  if (!all(c("fileIdx") %in% colnames(marker))) {
+    stop("Missing column 'fileIdx'")}
   
   xTransf <- x
   

--- a/R/transform.R
+++ b/R/transform.R
@@ -91,7 +91,10 @@
 #'
 #'@export
 
-mobilityTransform <- function(x, marker, tR, U, L) {
+mobilityTransform <- function(x, marker, 
+                              tR = 0, 
+                              U = numeric(), 
+                              L = numeric()) {
   
   ## sanity checks
   if (!class(x) %in% c("numeric","Spectra","OnDiskMSnExp")) 
@@ -106,18 +109,18 @@ mobilityTransform <- function(x, marker, tR, U, L) {
   if (is(x, "numeric")) {
     FUN = .transformNumeric
     FUN <- match.fun(FUN)
-    do.call(FUN, list(x = x, marker = marker, tR, U, L))
+    do.call(FUN, list(x = x, marker = marker, tR = tR, U = U, L = L))
   }
   else if (is(x, "Spectra")) {
     FUN = .transformSpectra
     FUN <- match.fun(FUN)
-    do.call(FUN, list(x = x, marker = marker, tR, U, L))
+    do.call(FUN, list(x = x, marker = marker, tR = tR, U = U, L = L))
   }
   
   else if (is(x, "OnDiskMSnExp")) {
     FUN = .transformOnDiskMSnExp
     FUN <- match.fun(FUN)
-    do.call(FUN, list(x = x, marker = marker, tR, U, L))
+    do.call(FUN, list(x = x, marker = marker, tR = tR, U = U, L = L))
   }
   
   
@@ -141,11 +144,11 @@ mobilityTransform <- function(x, marker, tR, U, L) {
 #' transformNumeric(x = rtime, marker = marker)
 #' transformNumeric(x = rtime, marker = marker[-1,], U = 30, L = 90)
 #' 
-.transformNumeric <- function(x, marker, tR, U, L) {
+.transformNumeric <- function(x, marker, ...) {
 
   convertMtime(x/60, 
                rtime = marker$rtime/60, 
-               mobility = marker$mobility, tR, U, L)
+               mobility = marker$mobility, ...)
   
 }
 
@@ -168,12 +171,12 @@ mobilityTransform <- function(x, marker, tR, U, L) {
 #'                      mobility = c(0, 2000))
 #' .transformSpectra(x = spectra_data, marker = marker)
 
-.transformSpectra <- function(x, marker, tR, U, L) {
+.transformSpectra <- function(x, marker, ...) {
   
   xTransf <- x
   xTransf$rtime <- convertMtime(xTransf$rtime/60, 
                             rtime = marker$rtime/60, 
-                            mobility = marker$mobility, tR, U, L)
+                            mobility = marker$mobility, ...)
   
   ## Data needs to be ordered by the migration time and spectrum IDs needs to 
   ## be removed to prevent errors in xcms 
@@ -207,7 +210,7 @@ mobilityTransform <- function(x, marker, tR, U, L) {
 #'                      
 #' .transformOnDiskMSnExp(x = raw_data, marker = marker)
 
-.transformOnDiskMSnExp <- function(x, marker, tR, U, L) {
+.transformOnDiskMSnExp <- function(x, marker, ...) {
   ## sanity checks
   if (!all(c("fileIdx") %in% colnames(marker))) {
     stop("Missing column 'fileIdx'")}
@@ -221,7 +224,7 @@ mobilityTransform <- function(x, marker, tR, U, L) {
     fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime <- 
       convertMtime(x = rt_file[[i]]/60, 
                    rtime = marker[marker$fileIdx == i,]$rtime/60, 
-                   mobility = marker[marker$fileIdx == i,]$mobility, tR, U, L)
+                   mobility = marker[marker$fileIdx == i,]$mobility, ...)
     
     ## Data needs to be ordered by the migration time and spectrum IDs needs to 
     ## be removed to prevent errors in xcms 

--- a/R/transform.R
+++ b/R/transform.R
@@ -227,15 +227,14 @@ mobilityTransform <- function(x, marker,
                    mobility = marker[marker$fileIdx == i,]$mobility, 
                    tR = tR, U = U, L = L)
     
-    ## Data needs to be ordered by the migration time and spectrum IDs needs to 
+    ## Data needs to be ordered by the migration time to 
     ## be removed to prevent errors in xcms 
     fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime <- 
       order(fData(xTransf)[fData(xTransf)$fileIdx == i,]$retentionTime, 
             decreasing = T)
     
   }
-  
-  fData(xTransf)$spectrumId <- NA
+
   
   return(xTransf)
   

--- a/man/dot-transformNumeric.Rd
+++ b/man/dot-transformNumeric.Rd
@@ -4,7 +4,7 @@
 \alias{.transformNumeric}
 \title{Transformation of numeric}
 \usage{
-.transformNumeric(x, marker, ...)
+.transformNumeric(x, marker, tR = tR, U = U, L = L)
 }
 \arguments{
 \item{x}{\code{numeric} migration time vector in seconds.}

--- a/man/dot-transformOnDiskMSnExp.Rd
+++ b/man/dot-transformOnDiskMSnExp.Rd
@@ -4,7 +4,7 @@
 \alias{.transformOnDiskMSnExp}
 \title{Transformation of OnDiskMSnExp}
 \usage{
-.transformOnDiskMSnExp(x, marker, ...)
+.transformOnDiskMSnExp(x, marker, tR = tR, U = U, L = L)
 }
 \arguments{
 \item{x}{\code{OnDiskMSnExp}-object that stores the migration times in seconds.}

--- a/man/dot-transformOnDiskMSnExp.Rd
+++ b/man/dot-transformOnDiskMSnExp.Rd
@@ -15,3 +15,15 @@
 \description{
 Transformation of OnDiskMSnExp
 }
+\examples{
+fl <- system.file("extdata/CEMS_metabolites_10ppm_pos_centroidedData.mzML", 
+package = "MobilityTransformationR")
+raw_data <- readMSData(files = fl,
+                       mode = "onDisk")
+marker <- data.frame(markerID = c("marker1", "marker2"),
+                     rtime = c(20,80),
+                     mobility = c(0, 2000),
+                     fileIdx = c(1,1))
+                     
+.transformOnDiskMSnExp(x = raw_data, marker = marker)
+}

--- a/man/dot-transformSpectra.Rd
+++ b/man/dot-transformSpectra.Rd
@@ -4,7 +4,7 @@
 \alias{.transformSpectra}
 \title{Transformation of Spectra}
 \usage{
-.transformSpectra(x, marker, ...)
+.transformSpectra(x, marker, tR = tR, U = U, L = L)
 }
 \arguments{
 \item{x}{\code{Spectra}-object that stores the migration times in seconds.}

--- a/man/mobilityTransform.Rd
+++ b/man/mobilityTransform.Rd
@@ -20,10 +20,9 @@ If \code{OnDiskMSnExp} is used in \code{x}, a third column "fileIdx" is required
 stores the file Index.
 One or two entries are required per file for the transformation and depending
 on the number of entries the transformation will be performed either on one or
-both markers.
+both markers.}
 
-@param ...
-Additional parameters passed to \code{convertMtime}, as for example \code{L}, \code{U},
+\item{...}{Additional parameters passed to \code{convertMtime}, as for example \code{L}, \code{U},
 and \code{tR}.}
 }
 \value{

--- a/man/mobilityTransform.Rd
+++ b/man/mobilityTransform.Rd
@@ -4,7 +4,7 @@
 \alias{mobilityTransform}
 \title{Effective mobility scale transformation of CE-MS data}
 \usage{
-mobilityTransform(x, marker, ...)
+mobilityTransform(x, marker, tR = 0, U = numeric(), L = numeric())
 }
 \arguments{
 \item{x}{\code{numeric} migration time vector, \code{Spectra} -object, or \code{MSnOnDiskExp}-object

--- a/vignettes/mobilityTransformationR.Rmd
+++ b/vignettes/mobilityTransformationR.Rmd
@@ -68,8 +68,7 @@ analyzed in R or other software.
 The <code>MobilityTransformationR</code> package can be installed directly from 
 GitHub using 
 ```{r, message=FALSE, warning=FALSE, message=FALSE}
-options(timeout=9999999)
-devtools::install_github("LiesaSalzer/MobilityTransformationR")
+devtools::install_github("LiesaSalzer/MobilityTransformationR", ref = "devel")
 ```
 
 ## Load required libries

--- a/vignettes/mobilityTransformationR.Rmd
+++ b/vignettes/mobilityTransformationR.Rmd
@@ -130,7 +130,7 @@ In order to check the right <code>mz</code>-, and <code>mt</code>-window and
 Note that the plot functions are adapted from LC-MS package MSnbase, which has 
 "retention time" as default x-axis label. 
 
-```{r EOF marker, message=FALSE}
+```{r EOF marker, message=FALSE, warning=FALSE}
 # mz tolerance depends on MS mass accuracy 
 tolerance <- 0.005
 
@@ -154,7 +154,7 @@ wide enough to get the right Paracetamol-peaks in all files, because single
 migration times might change significantly due to EOF-fluctuations between 
 measurements. 
 
-```{r EOF marker getMT, message=FALSE}
+```{r EOF marker getMT, message=FALSE, warning=FALSE}
 # get the MT of paracetamol
 paracetamol <- getMtime(raw_data,
                         mz = mz_paracetamol, 
@@ -173,7 +173,7 @@ not sufficient or ambiguity detection.
 For such reasons procaine was added to the mixture as positively charged 
 secondary marker. 
 
-```{r charged marker, message=FALSE}
+```{r charged marker, message=FALSE, warning=FALSE}
 mz_procaine <- c(237.160303 - tolerance, 237.160303 + tolerance)
 mt_procaine <- c(300, 800)
 
@@ -362,33 +362,7 @@ plot(chromatogram(lysine_mt_EIE),
      xlab = "MT (sec)")
 
 ```
-```{r amp, message=FALSE}
-# Example: Extract ion electropherogram (EIE) from lysine
-mz_AMP <- c(348.070913
- - tolerance, 348.070913
- + tolerance)
-mobilityRestriction <- c(-100, 100)
 
-
-# Extract ion electropherogram of compound
-AMP_EIE <-  mobility_data %>% 
-    filterMz(mz = mz_AMP) %>% 
-    filterRt(rt = mobilityRestriction)
-
-plot(chromatogram(AMP_EIE), 
-     main = expression(paste("AMP EIE - µ"[eff]," scale")), 
-     xlab = expression(paste("µ"[eff],"  (", frac("mm"^2,"kV min"),")"))
-     )
-
-# compare with extracted ion electropherogram of migration time scale
-AMP_mt_EIE <-  raw_data %>% 
-    filterMz(mz = mz_AMP) %>% filterRt(c(800,900))
-
-plot(chromatogram(AMP_mt_EIE),
-     main = "AMP EIE - MT scale", 
-     xlab = "MT (sec)")
-
-```
 
 # Session information
 

--- a/vignettes/mobilityTransformationR.Rmd
+++ b/vignettes/mobilityTransformationR.Rmd
@@ -308,7 +308,8 @@ The resulting <code>Spectra</code>-objects can then also be exported as
 #load the test data as spectra object
 spectra_data <- Spectra(fl, backend = MsBackendMzR())
 
-spectra_mobility <- mobilityTransform(spectra_data, marker[marker$fileIdx == 1,])
+spectra_mobility <- mobilityTransform(spectra_data, 
+                                      marker[marker$fileIdx == 1,])
 
 
 # #Transformed data can then be exported again as .mzML file to use in xcms or 


### PR DESCRIPTION
- mobilityTransform was moved from method to function (because of uncertainty). 
- .transformOnDiskMSnExp was adapted to prevent errors in xcms peak picking processes. 
- Changes on vignette and datafiles 